### PR TITLE
Fix "Failed to bind properties under 'metrics.prometheus'" error

### DIFF
--- a/LavalinkServer/src/main/java/lavalink/server/config/MetricsPrometheusConfigProperties.kt
+++ b/LavalinkServer/src/main/java/lavalink/server/config/MetricsPrometheusConfigProperties.kt
@@ -32,6 +32,6 @@ import org.springframework.stereotype.Component;
 @Component
 @ConfigurationProperties("metrics.prometheus")
 class MetricsPrometheusConfigProperties {
-  val enabled = false;
-  val endpoint: String = "";
+  var enabled = false;
+  var endpoint: String = "";
 }


### PR DESCRIPTION
This PR fixes the following error when starting lavalink:
```
***************************
APPLICATION FAILED TO START
***************************

Description:

Failed to bind properties under 'metrics.prometheus' to lavalink.server.config.MetricsPrometheusConfigProperties:

    Property: metrics.prometheus.endpoint
    Value: /metrics
    Origin: URL [file:application.yml] - 39:15
    Reason: No setter found for property: endpoint

Action:

Update your application's configuration
```