### PR TITLE
Fix archiveName deprecation

### DIFF
--- a/LavalinkServer/build.gradle
+++ b/LavalinkServer/build.gradle
@@ -40,7 +40,7 @@ ext {
 }
 
 bootJar {
-  archiveName = "Lavalink.jar"
+  archiveFileName = "Lavalink.jar"
 }
 
 sourceCompatibility = targetCompatibility = 11


### PR DESCRIPTION
This property has been replaced by archiveFileName.
https://docs.gradle.org/7.0/dsl/org.gradle.api.tasks.bundling.Jar.html#org.gradle.api.tasks.bundling.Jar:archiveName